### PR TITLE
Fixes for #16

### DIFF
--- a/templates/modular/form.html.twig
+++ b/templates/modular/form.html.twig
@@ -7,7 +7,18 @@
     </div>
     <div class="row">
 
-{% if form.message %}<div class="alert notices {{ form.message_color ?: 'green' }}"><p>{{ form.message }}</p></div>{% endif %}
+{% if form is null %}
+    {% set form = grav.session.getFlashObject('form') %}
+{% endif  %}
+
+{% if form.message %}
+    {% if form.inline_errors and form.messages %}
+        <div class="alert notices {{ form.message_color ?: 'green' }}"><p>{{ "FORM.VALIDATION_FAIL"|t|raw }}</p></div>
+    {% else %}
+        <div class="alert notices {{ form.message_color ?: 'green' }}"><p>{{ form.message|raw }}</p></div>
+    {% endif %}
+{% endif %}
+{% set scope = scope ?: 'data.' %}
 {% set multipart = '' %}
 {% set method = form.method|upper|default('POST') %}
 
@@ -17,7 +28,8 @@
     {% endif %}
 {% endfor %}
 
-{% set action = form.action ? base_url ~ form.action : page.url %}
+{% set action = form.action ? base_url ~ form.action : base_url ~ page.route ~ uri.params %}
+
 {% if (action == base_url_relative) %}
     {% set action = base_url_relative ~ '/' ~ page.slug %}
 {% endif %}
@@ -25,10 +37,13 @@
 <form name="{{ form.name }}"
       action="{{ action }}"
       method="{{ method }}"{{ multipart }}
+      {% if form.id %}id="{{ form.id }}"{% endif %}
       {% block form_classes %}
       {% if form.classes %}class="{{ form.classes }}"{% endif %}
       {% endblock %}
 >
+
+  {% block inner_markup_fields_start %}{% endblock %}
 
   <div class="col-md-6">
     {% for field in form.fields %}
@@ -37,7 +52,7 @@
         <div class="form-group">
           {% include "forms/fields/#{field.type}/#{field.type}.html.twig" ignore missing %}
         </div>
-      {% endif %}  
+      {% endif %}
     {% endfor %}
   </div>
   <div class="col-md-6">
@@ -47,22 +62,51 @@
         <div class="form-group">
           {% include "forms/fields/#{field.type}/#{field.type}.html.twig" ignore missing %}
         </div>
-      {% endif %}  
+      {% endif %}
     {% endfor %}
   </div>
 
+  {% include "forms/fields/formname/formname.html.twig" %}
+
+  {% block inner_markup_fields_end %}{% endblock %}
+
+  {% block inner_markup_buttons_start %}
+  <div class="buttons">
+  {% endblock %}
+
   <div class="col-lg-12 text-center">
-      <div class="form-group">
-        {% for button in form.buttons %}
-          <button 
-            {% block button_classes %}
-            class="{{ button.classes|default('button') }}"
-            {% endblock %}
-            type="{{ button.type|default('submit') }}"
-            >{{ button.value|t|default('Submit') }}</button>
-        {% endfor %}
-      </div>
+    <div class="form-group">
+      {% for button in form.buttons %}
+          {% if button.outerclasses is defined %}<div class="{{ button.outerclasses }}">{% endif %}
+              {% if button.url %}
+                  <a href="{{ button.url starts with 'http' ? button.url : url(button.url) }}">
+              {% endif %}
+              <button
+                    {% if button.id %}id="{{ button.id }}"{% endif %}
+                    {% block button_classes %}
+                    class="{{ button.classes|default('button') }}"
+                    {% endblock %}
+                    {% if button.disabled %}disabled="disabled"{% endif %}
+
+                    type="{{ button.type|default('submit') }}"
+
+                    {% if button.task %}
+                        name="task" value="{{ button.task }}"
+                    {% endif %}
+                >
+                    {{ button.value|t|default('Submit') }}
+              </button>
+              {% if button.url %}
+                  </a>
+              {% endif %}
+          {% if button.outerclasses is defined %}</div>{% endif %}
+      {% endfor %}
+    </div>
   </div>
 
-  {{ nonce_field('form', 'form-nonce') }}
+  {% block inner_markup_buttons_end %}
+  </div>
+  {% endblock %}
+
+  {{ nonce_field('form', 'form-nonce')|raw }}
 </form>


### PR DESCRIPTION
Some restructuring, formatting improvements. Tested with Grav v1.2.4, Form v2.7.0, Email v2.6.0, and Agency v1.4.0. Users should include a `/user/pages/01.home/thankyou/formdata.md` (per [Docs](https://learn.getgrav.org/forms/forms/reference-form-actions#display)) to verify that mails are sent on front-end.

In testing this fixes #16.