### PR TITLE
Support head and bottom JS asset inclusion

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -18,6 +18,7 @@
     <link href='//fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
     <link href='//fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
   {% endblock %}
+  {{ assets.js('head') }}  
   {{ assets.css() }}
 
   {% endblock head%}
@@ -43,7 +44,7 @@
     {% do assets.addJs('theme://js/cbpAnimatedHeader.js') %}
     {% do assets.addJs('theme://js/agency.js') %}
   {% endblock %}
-  {{ assets.js() }}
+  {{ assets.js('bottom') }}
 
 </body>
 </html>


### PR DESCRIPTION
Somethings in order to work correctly need JS to load in a blocking manner at the top of the document (example: HTML imports / eventually JS module imports). This would allow for usage of things that can live in the bottom showing up there and things specifically defining that they need to be in the head living there