### PR TITLE
Fix for issue from PR #20 - Added group as bottom for inline assets

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -37,12 +37,12 @@
   {% endblock %}
 
   {% block javascripts_bottom %}
-    {% do assets.add('jquery',101) %}
-    {% do assets.addJs('theme://js/bootstrap.min.js',100) %}
-    {% do assets.addJs('theme://js/jquery.easing.min.js') %}
-    {% do assets.addJs('theme://js/classie.js') %}
-    {% do assets.addJs('theme://js/cbpAnimatedHeader.js') %}
-    {% do assets.addJs('theme://js/agency.js') %}
+    {% do assets.add('jquery',{'priority':101,'group':'bottom'}) %}
+    {% do assets.addJs('theme://js/bootstrap.min.js',{'priority':100,'group':'bottom'}) %}
+    {% do assets.addJs('theme://js/jquery.easing.min.js',{'group':'bottom'}) %}
+    {% do assets.addJs('theme://js/classie.js',{'group':'bottom'}) %}
+    {% do assets.addJs('theme://js/cbpAnimatedHeader.js',{'group':'bottom'}) %}
+    {% do assets.addJs('theme://js/agency.js',{'group':'bottom'}) %}
   {% endblock %}
   {{ assets.js('bottom') }}
 


### PR DESCRIPTION
The bottom JS assets need to be told they are part of the bottom group otherwise the theme won't load any of this critical JS from bootstrap / etc.