### PR TITLE
Fix typo in block name

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -20,7 +20,7 @@
     <link href='//fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
   {% endblock %}
 
-  {% block javasripts %}
+  {% block javascripts %}
     {% do assets.addJs('jquery',{'priority':101,'group':'bottom'}) %}
     {% do assets.addJs('theme://js/bootstrap.min.js',{'priority':100,'group':'bottom'}) %}
     {% do assets.addJs('theme://js/jquery.easing.min.js',{'group':'bottom'}) %}


### PR DESCRIPTION
Correct block name from 'javasripts' to 'javascripts'.

Fixes #25 .
