### PR TITLE
Fix jQuery loading

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -21,7 +21,7 @@
   {% endblock %}
 
   {% block javasripts %}
-    {% do assets.addJs('jquery',{'priority':101,'group':'bottom'}) %}
+    {% do assets.addJs('jquery',{'priority':101,'group':'head'}) %}
     {% do assets.addJs('theme://js/bootstrap.min.js',{'priority':100,'group':'bottom'}) %}
     {% do assets.addJs('theme://js/jquery.easing.min.js',{'group':'bottom'}) %}
     {% do assets.addJs('theme://js/classie.js',{'group':'bottom'}) %}


### PR DESCRIPTION
The loading of jQuery is now moved to the 'head' group to prevent issues
with other things (e.g. Grav debug bar) needing it to be loaded sooner.

Fixes #24 .
